### PR TITLE
Fixes https://github.com/BentoBoxWorld/Likes/issues/22

### DIFF
--- a/src/main/java/world/bentobox/likes/listeners/ResetListener.java
+++ b/src/main/java/world/bentobox/likes/listeners/ResetListener.java
@@ -12,6 +12,7 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 
 import world.bentobox.bentobox.api.events.island.IslandCreatedEvent;
+import world.bentobox.bentobox.api.events.island.IslandDeleteEvent;
 import world.bentobox.bentobox.api.events.island.IslandDeletedEvent;
 import world.bentobox.bentobox.api.events.island.IslandResettedEvent;
 import world.bentobox.bentobox.api.events.island.IslandUnregisteredEvent;
@@ -43,8 +44,8 @@ public class ResetListener implements Listener
     public void onIslandCreated(IslandCreatedEvent event)
     {
         this.addon.getAddonManager().resetLikes(event.getPlayerUUID(),
-            event.getIsland().getUniqueId(),
-            event.getIsland().getWorld());
+                event.getIsland().getUniqueId(),
+                event.getIsland().getWorld());
     }
 
 
@@ -59,8 +60,8 @@ public class ResetListener implements Listener
         if (this.addon.getSettings().isResetLikes())
         {
             this.addon.getAddonManager().resetLikes(event.getPlayerUUID(),
-                event.getIsland().getUniqueId(),
-                event.getIsland().getWorld());
+                    event.getIsland().getUniqueId(),
+                    event.getIsland().getWorld());
         }
     }
 
@@ -76,8 +77,8 @@ public class ResetListener implements Listener
         if (this.addon.getSettings().isResetLikes())
         {
             this.addon.getAddonManager().resetLikes(event.getPlayerUUID(),
-                event.getIsland().getUniqueId(),
-                event.getIsland().getWorld());
+                    event.getIsland().getUniqueId(),
+                    event.getIsland().getWorld());
         }
     }
 
@@ -88,15 +89,15 @@ public class ResetListener implements Listener
      * @param event Event that must be handled.
      */
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-    public void onIslandDelete(IslandDeletedEvent event)
+    public void onIslandDelete(IslandDeleteEvent event)
     {
         this.addon.getAddonManager().removeObject(event.getIsland().getUniqueId());
     }
 
 
-// ---------------------------------------------------------------------
-// Section: Instance Variables
-// ---------------------------------------------------------------------
+    // ---------------------------------------------------------------------
+    // Section: Instance Variables
+    // ---------------------------------------------------------------------
 
 
     /**


### PR DESCRIPTION
Uses `IslandDeleteEvent` instead of `IslandDeletedEvent`. By the time
IslandDeletedEvent is fired, the Island object has gone and is null.