### PR TITLE
Only save changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <!-- Revision variable removes warning about dynamic version -->
         <revision>${build.version}-SNAPSHOT</revision>
         <!-- This allows to change between versions and snapshots. -->
-        <build.version>2.1.0</build.version>
+        <build.version>2.1.1</build.version>
         <build.number>-LOCAL</build.number>
     </properties>
 

--- a/src/main/java/world/bentobox/likes/database/objects/LikesObject.java
+++ b/src/main/java/world/bentobox/likes/database/objects/LikesObject.java
@@ -7,8 +7,15 @@
 package world.bentobox.likes.database.objects;
 
 
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
 import com.google.gson.annotations.Expose;
-import java.util.*;
 
 import world.bentobox.bentobox.api.logs.LogEntry;
 import world.bentobox.bentobox.database.objects.DataObject;
@@ -48,6 +55,7 @@ public class LikesObject implements DataObject
 
         this.likedBy.add(user);
         this.likes++;
+        setChanged();
     }
 
 
@@ -62,6 +70,7 @@ public class LikesObject implements DataObject
         {
             // Reduce only if player is in likedBy set.
             this.likes--;
+            setChanged();
         }
     }
 
@@ -77,6 +86,7 @@ public class LikesObject implements DataObject
 
         this.dislikedBy.add(user);
         this.dislikes++;
+        setChanged();
     }
 
 
@@ -91,6 +101,7 @@ public class LikesObject implements DataObject
         {
             // Reduce only if player is in dislikedBy set.
             this.dislikes--;
+            setChanged();
         }
     }
 
@@ -105,6 +116,7 @@ public class LikesObject implements DataObject
     {
         this.starredBy.put(user, value);
         this.stars += value;
+        setChanged();
     }
 
 
@@ -121,6 +133,7 @@ public class LikesObject implements DataObject
         {
             // Reduce only if player is in staredBy map.
             this.stars -= value;
+            setChanged();
         }
     }
 
@@ -155,6 +168,7 @@ public class LikesObject implements DataObject
     public void addLogRecord(LogEntry entry)
     {
         this.history.add(entry);
+        setChanged();
     }
 
 
@@ -225,6 +239,7 @@ public class LikesObject implements DataObject
         this.likedBy.clear();
         this.dislikedBy.clear();
         this.starredBy.clear();
+        setChanged();
     }
 
 
@@ -250,6 +265,7 @@ public class LikesObject implements DataObject
     public void setUniqueId(String uniqueId)
     {
         this.uniqueId = uniqueId;
+        setChanged();
     }
 
 
@@ -272,6 +288,7 @@ public class LikesObject implements DataObject
     public void setLikes(long likes)
     {
         this.likes = likes;
+        setChanged();
     }
 
 
@@ -294,6 +311,7 @@ public class LikesObject implements DataObject
     public void setDislikes(long dislikes)
     {
         this.dislikes = dislikes;
+        setChanged();
     }
 
 
@@ -316,6 +334,7 @@ public class LikesObject implements DataObject
     public void setLikedBy(Set<UUID> likedBy)
     {
         this.likedBy = likedBy;
+        setChanged();
     }
 
 
@@ -338,6 +357,7 @@ public class LikesObject implements DataObject
     public void setDislikedBy(Set<UUID> dislikedBy)
     {
         this.dislikedBy = dislikedBy;
+        setChanged();
     }
 
 
@@ -360,6 +380,7 @@ public class LikesObject implements DataObject
     public void setGameMode(String gameMode)
     {
         this.gameMode = gameMode;
+        setChanged();
     }
 
 
@@ -382,6 +403,7 @@ public class LikesObject implements DataObject
     public void setHistory(List<LogEntry> history)
     {
         this.history = history;
+        setChanged();
     }
 
 
@@ -415,6 +437,7 @@ public class LikesObject implements DataObject
     public void setStars(long stars)
     {
         this.stars = stars;
+        setChanged();
     }
 
 
@@ -437,9 +460,31 @@ public class LikesObject implements DataObject
     public void setStarredBy(Map<UUID, Integer> starredBy)
     {
         this.starredBy = starredBy;
+        setChanged();
+    }
+
+    /**
+     * @return the changed
+     */
+    public boolean isChanged() {
+        return changed;
     }
 
 
+    /**
+     * @param changed the changed to set
+     */
+    public void setChanged(boolean changed) {
+        this.changed = changed;
+    }
+    
+    /**
+     * Mark as changed
+     */
+    private void setChanged() {
+        this.changed = true;
+    }
+    
 // ---------------------------------------------------------------------
 // Section: Variables
 // ---------------------------------------------------------------------
@@ -499,4 +544,9 @@ public class LikesObject implements DataObject
     @Adapter(LogEntryListAdapter.class)
     @Expose
     private List<LogEntry> history = new LinkedList<>();
+    
+    /**
+     * Indicates whether this object has changed data or not. Used when saving.
+     */
+    private boolean changed;
 }

--- a/src/main/java/world/bentobox/likes/managers/LikesManager.java
+++ b/src/main/java/world/bentobox/likes/managers/LikesManager.java
@@ -7,10 +7,15 @@
 package world.bentobox.likes.managers;
 
 
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
 import org.bukkit.World;
 import org.eclipse.jdt.annotation.NonNull;
-import java.util.*;
-import java.util.stream.Collectors;
 
 import world.bentobox.bentobox.api.addons.GameModeAddon;
 import world.bentobox.bentobox.api.logs.LogEntry;
@@ -20,7 +25,12 @@ import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.likes.LikesAddon;
 import world.bentobox.likes.config.Settings;
 import world.bentobox.likes.database.objects.LikesObject;
-import world.bentobox.likes.events.*;
+import world.bentobox.likes.events.DislikeAddEvent;
+import world.bentobox.likes.events.DislikeRemoveEvent;
+import world.bentobox.likes.events.LikeAddEvent;
+import world.bentobox.likes.events.LikeRemoveEvent;
+import world.bentobox.likes.events.StarsAddEvent;
+import world.bentobox.likes.events.StarsRemoveEvent;
 import world.bentobox.likes.utils.Constants;
 import world.bentobox.likes.utils.Utils;
 import world.bentobox.likes.utils.collections.IndexedTreeSet;
@@ -274,7 +284,7 @@ public class LikesManager
      */
     public void save()
     {
-        this.likesCache.values().forEach(this.likesDatabase::saveObjectAsync);
+        this.likesCache.values().stream().filter(LikesObject::isChanged).forEach(this.likesDatabase::saveObjectAsync);
     }
 
 


### PR DESCRIPTION
This PR adds a flag to the LikeObject that is set when data is changed in it. This is then used when shutting down to avoid saving every item. This should help avoid long shutdowns when there are a lot of islands.

https://github.com/BentoBoxWorld/BentoBox/issues/1629
